### PR TITLE
Adds 95% credible intervals to correct, error and abstain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,13 @@
             <version>1.5.4</version>
         </dependency>
 
+        <!-- math -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/kotlin/com/tradeshift/iceberg/app/multi/MultiService.kt
+++ b/src/main/kotlin/com/tradeshift/iceberg/app/multi/MultiService.kt
@@ -43,7 +43,17 @@ class MultiService(
             for (i in 0..100) {
                 val threshold = i / 100.0
                 val cm = ConfusionMatrix.from(data, threshold)
-                stats.add(MultiStats(threshold, cm.correct, cm.error, cm.abstain))
+                stats.add(
+                    MultiStats(
+                        threshold,
+                        cm.correct,
+                        cm.correct95PercentCredibleInterval.toList(),
+                        cm.error,
+                        cm.error95PercentCredibleInterval.toList(),
+                        cm.abstain,
+                        cm.abstain95PercentCredibleInterval.toList()
+                    )
+                )
             }
             stats
         }

--- a/src/main/kotlin/com/tradeshift/iceberg/app/multi/dto/MultiStats.kt
+++ b/src/main/kotlin/com/tradeshift/iceberg/app/multi/dto/MultiStats.kt
@@ -3,6 +3,9 @@ package com.tradeshift.iceberg.app.multi.dto
 data class MultiStats(
     val threshold: Double,
     val correct: Double,
+    val correctCredibleInterval: List<Double>,
     val error: Double,
-    val abstain: Double
+    val errorCredibleInterval: List<Double>,
+    val abstain: Double,
+    val abstainCredibleInterval: List<Double>
 )

--- a/src/main/kotlin/com/tradeshift/iceberg/core/ConfusionMatrix.kt
+++ b/src/main/kotlin/com/tradeshift/iceberg/core/ConfusionMatrix.kt
@@ -3,6 +3,7 @@ package com.tradeshift.iceberg.core
 import com.google.common.collect.HashBasedTable
 import com.google.common.collect.ImmutableTable
 import com.tradeshift.iceberg.app.multi.dto.MultiDatum
+import org.apache.commons.math3.distribution.BetaDistribution
 
 class ConfusionMatrix(
     private val matrix: ImmutableTable<String, String, Int>
@@ -23,18 +24,27 @@ class ConfusionMatrix(
     }
 
     val correct by lazy {
-        if (nTotal == 0) Double.NaN
-        nCorrect.toDouble() / nTotal
+        if (nTotal == 0) Double.NaN else nCorrect.toDouble() / nTotal
+    }
+
+    val correct95PercentCredibleInterval: Pair<Double, Double> by lazy {
+        if (nTotal == 0) Pair(Double.NaN, Double.NaN) else binomial95PercentCredibleInterval(nCorrect, nTotal)
     }
 
     val error by lazy {
-        if (nTotal == 0) Double.NaN
-        nError.toDouble() / nTotal
+        if (nTotal == 0) Double.NaN else nError.toDouble() / nTotal
+    }
+
+    val error95PercentCredibleInterval: Pair<Double, Double> by lazy {
+        if (nTotal == 0) Pair(Double.NaN, Double.NaN) else binomial95PercentCredibleInterval(nError, nTotal)
     }
 
     val abstain by lazy {
-        if (nTotal == 0) Double.NaN
-        nAbstain.toDouble() / nTotal
+        if (nTotal == 0) Double.NaN else nAbstain.toDouble() / nTotal
+    }
+
+    val abstain95PercentCredibleInterval: Pair<Double, Double> by lazy {
+        if (nTotal == 0) Pair(Double.NaN, Double.NaN) else binomial95PercentCredibleInterval(nAbstain, nTotal)
     }
 
     val recall by lazy {
@@ -57,6 +67,21 @@ class ConfusionMatrix(
 
     companion object {
         const val ABSTAIN: String = "ABSTAIN"
+
+        /**
+         * The 95 percent credible interval (2.5% to 97.5%) of the rate of success in a binomial distribution, from which
+         * you've observed #successes out of #total trials under a uniform beta(1,1) prior on the rate of success.
+         */
+        fun binomial95PercentCredibleInterval(successes: Int, total: Int): Pair<Double, Double> {
+            val alpha = successes + 1
+            val beta = (total - successes) + 1
+            val b = BetaDistribution(alpha.toDouble(), beta.toDouble())
+
+            val p025 = b.inverseCumulativeProbability(0.025)
+            val p975 = b.inverseCumulativeProbability(0.975)
+
+            return Pair(p025, p975)
+        }
 
         fun from(data: List<MultiDatum>, threshold: Double): ConfusionMatrix {
             val table = HashBasedTable.create<String, String, Int>()

--- a/src/test/kotlin/com/tradeshift/iceberg/core/ConfusionMatrixTest.kt
+++ b/src/test/kotlin/com/tradeshift/iceberg/core/ConfusionMatrixTest.kt
@@ -22,6 +22,9 @@ class ConfusionMatrixTest {
         assertTrue(cm.abstain.isNaN())
         assertTrue(cm.recall.isNaN())
         assertTrue(cm.precision.isNaN())
+        assertTrue(cm.correct95PercentCredibleInterval.toList().all { it.isNaN() })
+        assertTrue(cm.error95PercentCredibleInterval.toList().all { it.isNaN() })
+        assertTrue(cm.abstain95PercentCredibleInterval.toList().all { it.isNaN() })
     }
 
     @Test
@@ -47,6 +50,15 @@ class ConfusionMatrixTest {
         assertEquals(0.0, cm.abstain, 0.0)
         assertEquals(((5.0 / 6.0) + (7.0 / 10.0)) / 2, cm.recall, 0.0)
         assertEquals(((5.0 / 8.0) + (7.0 / 8.0)) / 2, cm.precision, 0.0)
+
+        assertEquals(0.5010, cm.correct95PercentCredibleInterval.first, 0.0001)
+        assertEquals(0.8968, cm.correct95PercentCredibleInterval.second, 0.0001)
+
+        assertEquals(0.1031, cm.error95PercentCredibleInterval.first, 0.0001)
+        assertEquals(0.4989, cm.error95PercentCredibleInterval.second, 0.0001)
+
+        assertEquals(0.0014, cm.abstain95PercentCredibleInterval.first, 0.0001)
+        assertEquals(0.1950, cm.abstain95PercentCredibleInterval.second, 0.0001)
     }
 
     @Test


### PR DESCRIPTION
We should reflect our uncertainty about our estimates based on the number of samples we have.

Example output for the iris dataset

```
{
  "model": {
    "username": "rbp",
    "id": "iris",
    "threshold": 0.0,
    "errorCost": 5.0,
    "abstainCost": 1.0,
    "correctCost": 0.0
  },
  "samples": 75,
  "outcomes": 4,
  "stats": [
    {
      "threshold": 0.0,
      "correct": 0.68,
      "correctCredibleInterval": [
        0.567452098067079,
        0.7745701953764832
      ],
      "error": 0.32,
      "errorCredibleInterval": [
        0.22542980462351667,
        0.43254790193292103
      ],
      "abstain": 0.0,
      "abstainCredibleInterval": [
        3.330733327355105E-4,
        0.047378753867453424
      ]
    },
    ...
```