### PR TITLE
fix broken table by using v6 of react-table

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15083,10 +15083,10 @@
         "sourcemapped-stacktrace-node": "2.1.8"
       }
     },
-    "react-table": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.9.2.tgz",
-      "integrity": "sha512-sTbNHU8Um0xRtmCd1js873HXnXaMWeBwZoiljuj0l1d44eaqjKyYPK/3HCBbJg1yeE2O5pQJ3Km0tlm9niNL9w==",
+    "react-table-v6": {
+      "version": "6.8.6",
+      "resolved": "https://registry.npmjs.org/react-table-v6/-/react-table-v6-6.8.6.tgz",
+      "integrity": "sha512-jxo20BTIU/tQxToOZFnfr0V123VSQ2kNdxR+JbA7V4Zfj1jNtBaiFW/lYgVwejnbnUOuj96pV8Dd+yXXMdAMDA==",
       "requires": {
         "classnames": "^2.2.5"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.3",
     "react-snap": "^1.23.0",
-    "react-table": "^6.9.2",
+    "react-table-v6": "^6.8.6",
     "styled-components": "^4.1.3",
     "typescript": "^3.3.3"
   },

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -20,7 +20,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://unpkg.com/react-table@latest/react-table.css"
+      href="https://unpkg.com/react-table-v6@latest/react-table.css"
     />
     <link
       rel="stylesheet"

--- a/frontend/src/pages/ModelsList/ModelsList.js
+++ b/frontend/src/pages/ModelsList/ModelsList.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import ReactTable from 'react-table';
+import ReactTable from 'react-table-v6';
 import TopBar from 'components/TopBar/TopBar';
 import ModelsListStyles from './ModelsListStyles';
 


### PR DESCRIPTION
Temporary fix for broken tables. They have upgraded to a new version and the old version is still available under a new name.

In the future, we should upgrade the new version or use something else for the tables.